### PR TITLE
Make Intro Copy and CTA Text User Editable

### DIFF
--- a/blocks/ajg-native-lands-search/block.json
+++ b/blocks/ajg-native-lands-search/block.json
@@ -16,6 +16,18 @@
 	  "blockId": {
 		"type": "string",
 		"default": ""
+	  },
+	  "headline": {
+		"type": "string",
+		"default": "Are you on unceded indigenous land?"
+	  },
+	  "description": {
+		"type": "string",
+		"default": "Enter a street address, town, or zip code to see whose."
+	  },
+	  "cta": {
+		"type": "string",
+		"default": "Tell me."
 	  }
 	}
 }

--- a/blocks/ajg-native-lands-search/src/edit.js
+++ b/blocks/ajg-native-lands-search/src/edit.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  *
  * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, RichText } from '@wordpress/block-editor';
 
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
@@ -31,16 +31,34 @@ import './editor.scss';
  */
 export default function Edit(props) {
 	const {attributes, clientId, setAttributes} = props;
-	const {blockId} = attributes;
+	const {blockId, cta, description, headline} = attributes;
 	if(!blockId){
 		setAttributes({blockId: clientId})
 	}
 	return (
-		<p { ...useBlockProps() }>
-			{ __(
-				'Native Lands Search – hello from the editor!',
-				'ajg-native-lands-search'
-			) }
-		</p>
+		<div { ...useBlockProps() }>
+			<div className="wp-block-ajgnl-ajg-native-lands-search__intro">
+				<RichText
+					tagName="h4"
+					value={ headline }
+					onChange={ ( headline ) => setAttributes( { headline } ) }
+				/>
+				<RichText
+					tagName="p"
+					value={ description }
+					onChange={ ( description ) => setAttributes( { description } ) }
+				/>
+			</div>
+			<div className="wp-block-ajgnl-ajg-native-lands-search__search">
+				<input type="text" />
+				<button>
+					<RichText
+						tagName="span"
+						value={ cta }
+						onChange={ ( cta ) => setAttributes( { cta } ) }
+					/>
+				</button>
+			</div>
+		</div>
 	);
 }

--- a/blocks/ajg-native-lands-search/src/save.js
+++ b/blocks/ajg-native-lands-search/src/save.js
@@ -23,16 +23,20 @@ import { useBlockProps } from '@wordpress/block-editor';
  * @return {WPElement} Element to render.
  */
 export default function save({attributes}) {
-	const { blockId } = attributes;
+	const { blockId, cta, description, headline } = attributes;
 	return (
 		<div { ...useBlockProps.save() }>
 			<div className="wp-block-ajgnl-ajg-native-lands-search__intro">
-				<h4 className="wp-block-ajgnl-ajg-native-lands-search__headline">Are you on unceded indigenous land?</h4>
-				<p className="wp-block-ajgnl-ajg-native-lands-search__description">Enter a street address, town, or zip code to see whose.</p>
+				{headline.length > 0 &&
+					<h4 className="wp-block-ajgnl-ajg-native-lands-search__headline">{headline}</h4>
+				}
+				{description.length > 0 &&
+					<p className="wp-block-ajgnl-ajg-native-lands-search__description">{description}</p>
+				}
 			</div>
 			<form action="javascript:void(0);" className="wp-block-ajgnl-ajg-native-lands-search__search" data-ajgnls-search={blockId}>
 				<input type="text" data-ajgnls-query={blockId} />
-				<input type="submit" value="Tell me." data-ajgnls-submit={blockId} />
+				<input type="submit" value={cta} data-ajgnls-submit={blockId} />
 			</form>
 			<p className="wp-block-ajgnl-ajg-native-lands-search__error">There was a problem searching for that location.<br/><a href="https://native-land.ca" target="_blank" rel="noopener">Learn more -- explore the full map.</a></p>
 			<p className="wp-block-ajgnl-ajg-native-lands-search__no-results">There are no indigenous nations that correspond to that location; results are most likely for folks in the Americans and Oceania.<br/><a href="https://native-land.ca" target="_blank" rel="noopener">Learn more -- explore the full map.</a></p>


### PR DESCRIPTION
* Create new attributes in block, using current copy as defaults
* Use RichText components in the editor to allow each element's copy to be edited
* Display attribute data in save view
* For Intro Copy, do not render if string is removed

Fixes #3 